### PR TITLE
record button changes color depending on if audio is being recorded

### DIFF
--- a/src/blocks/VoiceApp.tsx
+++ b/src/blocks/VoiceApp.tsx
@@ -87,13 +87,13 @@ const AudioButtons = ({ onSave }: AudioButtonProps) => {
       backgroundColor: 'none', padding: '20px', display: 'flex', justifyContent: 'center', alignItems: 'flex-end', gap: '20px', width: '100%'
     }} >
       {/* Microphone button */}
-      <Fab onClick={toggleRecord} sx={{ width: { xs: "150px", md: "250px", lg: "250px" }, height: { xs: "150px", md: "250px", lg: "250px" } }} style={{
-        backgroundColor: 'black'
-      }}>
-        <MicIcon style={{
-          borderRadius: '50%',
-          color: 'white',
-        }} />
+      <Fab onClick={toggleRecord} sx={{ width: { xs: "150px", md: "250px", lg: "250px" }, height: { xs: "150px", md: "250px", lg: "250px" } }}
+        style={
+          isRecording ? 
+          {backgroundColor: 'white', border: "5px solid black"} : 
+          {backgroundColor: "black"}
+      }>
+        <MicIcon style={isRecording ? {color: 'black',}: { color: 'white',}} />
       </Fab>
       {/* Post button */}
       <Fab sx={{


### PR DESCRIPTION
## Purpose
Here I have added different colors to the record button to denote whether the app is recording or not.
Not recording: 
<img width="306" alt="Screenshot 2024-06-06 at 1 41 05 PM" src="https://github.com/fractal-bootcamp/Miniapp-Builder/assets/118918889/d09b4f57-b172-4312-ac9c-51c51af4be05">

Recording: 
<img width="294" alt="Screenshot 2024-06-06 at 1 41 32 PM" src="https://github.com/fractal-bootcamp/Miniapp-Builder/assets/118918889/e77c3b38-4fa3-4020-bb4e-5798a921934e">



<!--
ELLIPSIS_HIDDEN
-->


----

| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 67d3dd747dd5c82406fe0322dcbf40fa7fb72556  | 
|--------|--------|

### Summary:
This PR updates the record button in `VoiceApp.tsx` to change colors based on the recording state, enhancing user interface clarity.

**Key points**:
- Updated `toggleRecord` in `AudioButtons` component in `src/blocks/VoiceApp.tsx`.
- Button color changes based on `isRecording` state.
- Uses conditional styling for `Fab` and `MicIcon` components.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!--
ELLIPSIS_HIDDEN
-->
